### PR TITLE
Bump version of manifold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "^3.8.4"
-pysad = {git = "https://github.com/Dedaub/pySAD.git", tag="v0.1.3"}
+pysad = {git = "https://github.com/Dedaub/pySAD", tag="v0.1.3"}
 msgspec = "^0.15.1"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "^3.8.4"
-pysad = {git = "https://github.com/Dedaub/pySAD", tag="v0.1.0"}
+pysad = {git = "https://github.com/Dedaub/pySAD", tag="v0.1.3"}
 msgspec = "^0.15.1"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 aiohttp = "^3.8.4"
-pysad = {git = "https://github.com/Dedaub/pySAD", tag="v0.1.3"}
+pysad = {git = "https://github.com/Dedaub/pySAD.git", tag="v0.1.3"}
 msgspec = "^0.15.1"
 
 


### PR DESCRIPTION
This commit bumps the version of manifold to allow for compatibility with pySAD 0.1.3, which is a requirement for dense.